### PR TITLE
Remove draw.io as it isn't open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ engine
 
 ## Javascript
 
-- [Draw.io](https://github.com/jgraph/drawio) - Online diagramming web site
 - [Spectrum Chat](https://github.com/withspectrum/spectrum) - Simple, powerful online communities.
 - [RocketChat](https://github.com/RocketChat/Rocket.Chat) - Free Open Source Solution for team communications
 - [Paisley](https://github.com/uduakabaci/Paisley) - Paisley is an open-source alternative to mailbrew built with freedom in mind.


### PR DESCRIPTION
It is stated under their license section that:

> The source code authored by us in this repo is licensed under a modified Apache v2 license. This project is not an open source project as a result.

https://github.com/jgraph/drawio?tab=readme-ov-file#license