### PR TITLE
fix: fixed anchor link in README for lucky-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project is inspired by [free-for.dev](https://free-for.dev).
   - [Plug](#plug)
 - [Java](#java)
 - [Crystal](#crystal)
-  - [Lucky](#lucky)
+  - [Lucky](#lucky-framework)
 - [Clojure](#clojure)
 - [C#](#c#)
 


### PR DESCRIPTION
fixes #343  by adding correct anchor link for lucky-framework 